### PR TITLE
Fix: Use absolute paths for data fetching on GitHub Pages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -48,13 +48,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         console.log('Attempting to load all JSON data...');
         try {
             const results = await Promise.all([
-                fetchData('../data/exam_results.json'),
-                fetchData('../data/modul1.json'),
-                fetchData('../data/modul2.json'),
-                fetchData('../data/modul3.json'),
-                fetchData('../data/modul4.json'),
-                fetchData('../data/modul5.json'),
-                fetchData('../data/quiz_questions.json')
+                fetchData('/aca_dahsboard/data/exam_results.json'),
+                fetchData('/aca_dahsboard/data/modul1.json'),
+                fetchData('/aca_dahsboard/data/modul2.json'),
+                fetchData('/aca_dahsboard/data/modul3.json'),
+                fetchData('/aca_dahsboard/data/modul4.json'),
+                fetchData('/aca_dahsboard/data/modul5.json'),
+                fetchData('/aca_dahsboard/data/quiz_questions.json')
                 // Add fetch for glossar.json here if it exists, then adjust indices below
             ]);
 


### PR DESCRIPTION
Changed data file paths in js/app.js from relative (e.g., ../data/file.json) to absolute (e.g., /aca_dahsboard/data/file.json).

This ensures that data is fetched from the correct URL when deployed on GitHub Pages under a project site structure (username.github.io/repository_name/), preventing 404 errors caused by incorrect relative path resolution.